### PR TITLE
Enhance onboarding and progress UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,14 +14,20 @@ Thank you to the teams at Groq and Cartesia for providing access to their APIs f
 ## Developing
 
 -   Clone the repository
--   Copy `.env.example` to `.env.local` and fill in the environment variables.
+-   Copy `.env.example` to `.env.local`.
+-   Set `GROQ_API_KEY` and `CARTESIA_API_KEY` in `.env.local` so the assistant can transcribe and speak.
 -   Run `pnpm install` to install dependencies.
 -   Run `pnpm dev` to start the development server.
 -   Run `pnpm lint` to check code style.
 -   Run `pnpm build` to generate a production build.
 
-On first launch, visit `/onboarding` to choose your language and focus areas. These settings are saved in your browser for future visits.
-Progress for each focus area increases slightly with every conversation.
+## Usage
+
+1. Open the app and complete the onboarding flow to choose your language and focus areas.
+2. Ask questions by typing or speaking into your microphone.
+3. Listen to the spoken response and watch your progress bars update after each chat.
+4. Visit `/admin` to view your saved settings, progress, and API key status.
+
 
 ## Documentation
 - [Product Requirements](docs/PRD.md)

--- a/app/admin/client.tsx
+++ b/app/admin/client.tsx
@@ -10,11 +10,14 @@ export default function AdminClient({
 }) {
   const [lang, setLang] = useState<string | null>(null);
   const [focus, setFocus] = useState<string[]>([]);
+  const [progress, setProgress] = useState<Record<string, number>>({});
 
   useEffect(() => {
     setLang(localStorage.getItem("language"));
     const stored = localStorage.getItem("focusAreas");
     if (stored) setFocus(JSON.parse(stored));
+    const storedProg = localStorage.getItem("progress");
+    if (storedProg) setProgress(JSON.parse(storedProg));
   }, []);
 
   return (
@@ -27,6 +30,27 @@ export default function AdminClient({
       <div className="space-y-1">
         <p>Saved language: {lang || "None"}</p>
         <p>Focus areas: {focus.length > 0 ? focus.join(", ") : "None"}</p>
+      </div>
+      <div className="space-y-1">
+        <h2 className="font-medium">Progress</h2>
+        {Object.keys(progress).length === 0 ? (
+          <p>No progress yet.</p>
+        ) : (
+          focus.map((area) => (
+            <div key={area}>
+              <div className="flex justify-between text-sm">
+                <span>{area}</span>
+                <span>{progress[area] ?? 0}%</span>
+              </div>
+              <div className="h-2 bg-neutral-200 rounded">
+                <div
+                  className="h-2 bg-blue-500 rounded"
+                  style={{ width: `${progress[area] ?? 0}%` }}
+                />
+              </div>
+            </div>
+          ))
+        )}
       </div>
     </div>
   );

--- a/app/onboarding/page.tsx
+++ b/app/onboarding/page.tsx
@@ -17,6 +17,8 @@ export default function Onboarding() {
   const [language, setLanguage] = useState<string>("English");
   const [focus, setFocus] = useState<string[]>([]);
 
+  const totalSteps = 2;
+
   useEffect(() => {
     const savedLang = localStorage.getItem("language");
     const savedFocus = localStorage.getItem("focusAreas");
@@ -43,8 +45,13 @@ export default function Onboarding() {
     }
   }
 
+  function back() {
+    if (step === 2) setStep(1);
+  }
+
   return (
     <div className="max-w-md mx-auto space-y-4">
+      <progress value={step} max={totalSteps} className="w-full h-2" />
       {step === 1 && (
         <>
           <h1 className="text-xl font-bold text-center">Choose language</h1>
@@ -89,12 +96,22 @@ export default function Onboarding() {
         </>
       )}
 
-      <button
-        onClick={next}
-        className="w-full p-2 bg-black text-white rounded"
-      >
-        {step === 1 ? "Next" : "Finish"}
-      </button>
+      <div className="flex gap-2">
+        {step === 2 && (
+          <button
+            onClick={back}
+            className="p-2 w-24 rounded border border-black dark:border-white"
+          >
+            Back
+          </button>
+        )}
+        <button
+          onClick={next}
+          className="flex-1 p-2 bg-black text-white rounded"
+        >
+          {step === 1 ? "Next" : "Finish"}
+        </button>
+      </div>
     </div>
   );
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -107,10 +107,16 @@ export default function Home() {
 
 		const submittedAt = Date.now();
 
-		const response = await fetch("/api", {
-			method: "POST",
-			body: formData,
-		});
+                let response: Response;
+                try {
+                        response = await fetch("/api", {
+                                method: "POST",
+                                body: formData,
+                        });
+                } catch {
+                        toast.error("Network error. Please try again.");
+                        return prevMessages;
+                }
 
 		const transcript = decodeURIComponent(
 			response.headers.get("X-Transcript") || ""
@@ -167,7 +173,7 @@ export default function Home() {
                         <div className="space-y-2 text-center mb-6">
                                 <h1 className="text-2xl font-bold">{headline}</h1>
                                 <p className="text-sm">{affirmation}</p>
-                                {focus.length > 0 && (
+                                {focus.length > 0 ? (
                                         <div className="space-y-2">
                                                 {focus.map((area) => (
                                                         <div key={area}>
@@ -184,6 +190,12 @@ export default function Home() {
                                                         </div>
                                                 ))}
                                         </div>
+                                ) : (
+                                        <p className="text-neutral-500 dark:text-neutral-400 text-sm">
+                                                No focus areas selected. Visit&nbsp;
+                                                <A href="/onboarding">onboarding</A>
+                                                &nbsp;to choose some.
+                                        </p>
                                 )}
                         </div>
 


### PR DESCRIPTION
## Summary
- show alert when no focus areas have been chosen
- persist onboarding selections in localStorage with progress tracking
- display saved progress and API key status in the admin page
- document setup and usage steps in the README

## Testing
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_b_6871bc27be948325bf6ff0b5501a64df