### PR TITLE
Enhance assistant UX and error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,14 +14,20 @@ Thank you to the teams at Groq and Cartesia for providing access to their APIs f
 ## Developing
 
 -   Clone the repository
--   Copy `.env.example` to `.env.local` and fill in the environment variables.
+-   Copy `.env.example` to `.env.local`.
+-   Set `GROQ_API_KEY` and `CARTESIA_API_KEY` in `.env.local` so the assistant can transcribe and speak.
 -   Run `pnpm install` to install dependencies.
 -   Run `pnpm dev` to start the development server.
 -   Run `pnpm lint` to check code style.
 -   Run `pnpm build` to generate a production build.
 
-On first launch, visit `/onboarding` to choose your language and focus areas. These settings are saved in your browser for future visits.
-Progress for each focus area increases slightly with every conversation.
+## Usage
+
+1. Open the app and complete the onboarding flow to choose your language and focus areas. You must select at least one focus area before finishing.
+2. Ask questions by typing or speaking into your microphone.
+3. Listen to the spoken response and watch your progress bars update after each chat.
+4. Visit `/admin` to view your saved settings, progress, and API key status.
+
 
 ## Documentation
 - [Product Requirements](docs/PRD.md)

--- a/app/admin/client.tsx
+++ b/app/admin/client.tsx
@@ -1,5 +1,6 @@
 "use client";
 import { useEffect, useState } from "react";
+import Link from "next/link";
 
 export default function AdminClient({
   groq,
@@ -10,11 +11,14 @@ export default function AdminClient({
 }) {
   const [lang, setLang] = useState<string | null>(null);
   const [focus, setFocus] = useState<string[]>([]);
+  const [progress, setProgress] = useState<Record<string, number>>({});
 
   useEffect(() => {
     setLang(localStorage.getItem("language"));
     const stored = localStorage.getItem("focusAreas");
     if (stored) setFocus(JSON.parse(stored));
+    const storedProg = localStorage.getItem("progress");
+    if (storedProg) setProgress(JSON.parse(storedProg));
   }, []);
 
   return (
@@ -28,6 +32,30 @@ export default function AdminClient({
         <p>Saved language: {lang || "None"}</p>
         <p>Focus areas: {focus.length > 0 ? focus.join(", ") : "None"}</p>
       </div>
+      <div className="space-y-1">
+        <h2 className="font-medium">Progress</h2>
+        {Object.keys(progress).length === 0 ? (
+          <p>No progress yet.</p>
+        ) : (
+          focus.map((area) => (
+            <div key={area}>
+              <div className="flex justify-between text-sm">
+                <span>{area}</span>
+                <span>{progress[area] ?? 0}%</span>
+              </div>
+              <div className="h-2 bg-neutral-200 dark:bg-neutral-700 rounded">
+                <div
+                  className="h-2 bg-blue-500 rounded"
+                  style={{ width: `${progress[area] ?? 0}%` }}
+                />
+              </div>
+            </div>
+          ))
+        )}
+      </div>
+      <p className="text-center pt-4">
+        <Link className="underline" href="/">Back to Home</Link>
+      </p>
     </div>
   );
 }

--- a/app/onboarding/page.tsx
+++ b/app/onboarding/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect } from "react";
+import { toast } from "sonner";
 import { useRouter } from "next/navigation";
 
 const areas = [
@@ -16,6 +17,8 @@ export default function Onboarding() {
   const [step, setStep] = useState(1);
   const [language, setLanguage] = useState<string>("English");
   const [focus, setFocus] = useState<string[]>([]);
+
+  const totalSteps = 2;
 
   useEffect(() => {
     const savedLang = localStorage.getItem("language");
@@ -35,6 +38,10 @@ export default function Onboarding() {
       localStorage.setItem("language", language);
       setStep(2);
     } else {
+      if (focus.length === 0) {
+        toast.error("Please select at least one focus area.");
+        return;
+      }
       localStorage.setItem("focusAreas", JSON.stringify(focus));
       const progress: Record<string, number> = {};
       for (const area of focus) progress[area] = 0;
@@ -43,8 +50,13 @@ export default function Onboarding() {
     }
   }
 
+  function back() {
+    if (step === 2) setStep(1);
+  }
+
   return (
     <div className="max-w-md mx-auto space-y-4">
+      <progress value={step} max={totalSteps} className="w-full h-2" />
       {step === 1 && (
         <>
           <h1 className="text-xl font-bold text-center">Choose language</h1>
@@ -89,12 +101,22 @@ export default function Onboarding() {
         </>
       )}
 
-      <button
-        onClick={next}
-        className="w-full p-2 bg-black text-white rounded"
-      >
-        {step === 1 ? "Next" : "Finish"}
-      </button>
+      <div className="flex gap-2">
+        {step === 2 && (
+          <button
+            onClick={back}
+            className="p-2 w-24 rounded border border-black dark:border-white"
+          >
+            Back
+          </button>
+        )}
+        <button
+          onClick={next}
+          className="flex-1 p-2 bg-black text-white rounded"
+        >
+          {step === 1 ? "Next" : "Finish"}
+        </button>
+      </div>
     </div>
   );
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -65,17 +65,21 @@ export default function Home() {
 
         const vad = useMicVAD({
                 startOnLoad: true,
-		onSpeechEnd: (audio) => {
-			player.stop();
-			const wav = utils.encodeWAV(audio);
-			const blob = new Blob([wav], { type: "audio/wav" });
-			startTransition(() => submit(blob));
-			const isFirefox = navigator.userAgent.includes("Firefox");
-			if (isFirefox) vad.pause();
-		},
-		positiveSpeechThreshold: 0.6,
-		minSpeechFrames: 4,
-	});
+                onSpeechEnd: (audio) => {
+                        player.stop();
+                        const wav = utils.encodeWAV(audio);
+                        const blob = new Blob([wav], { type: "audio/wav" });
+                        startTransition(() => submit(blob));
+                        const isFirefox = navigator.userAgent.includes("Firefox");
+                        if (isFirefox) vad.pause();
+                },
+                positiveSpeechThreshold: 0.6,
+                minSpeechFrames: 4,
+        });
+
+        useEffect(() => {
+                if (vad.errored) toast.error("Speech detection failed to load.");
+        }, [vad.errored]);
 
 	useEffect(() => {
 		function keyDown(e: KeyboardEvent) {
@@ -107,10 +111,16 @@ export default function Home() {
 
 		const submittedAt = Date.now();
 
-		const response = await fetch("/api", {
-			method: "POST",
-			body: formData,
-		});
+                let response: Response;
+                try {
+                        response = await fetch("/api", {
+                                method: "POST",
+                                body: formData,
+                        });
+                } catch {
+                        toast.error("Network error. Please try again.");
+                        return prevMessages;
+                }
 
 		const transcript = decodeURIComponent(
 			response.headers.get("X-Transcript") || ""
@@ -128,10 +138,18 @@ export default function Home() {
 		}
 
                 const latency = Date.now() - submittedAt;
-                player.play(response.body, () => {
-                        const isFirefox = navigator.userAgent.includes("Firefox");
-                        if (isFirefox) vad.start();
-                });
+                player
+                        .play(response.body, () => {
+                                const isFirefox = navigator.userAgent.includes(
+                                        "Firefox"
+                                );
+                                if (isFirefox) vad.start();
+                        })
+                        .catch(() =>
+                                toast.error(
+                                        "Audio playback failed. Please try again."
+                                )
+                        );
                 setInput(transcript);
 
                 const stored = localStorage.getItem("progress");
@@ -161,13 +179,14 @@ export default function Home() {
 		startTransition(() => submit(input));
 	}
 
-	return (
+        return (
                 <>
-                        <div className="pb-4 min-h-28" />
-                        <div className="space-y-2 text-center mb-6">
+                        <div className="w-full max-w-md mx-auto">
+                                <div className="pb-4 min-h-28" />
+                                <div className="space-y-2 text-center mb-6">
                                 <h1 className="text-2xl font-bold">{headline}</h1>
                                 <p className="text-sm">{affirmation}</p>
-                                {focus.length > 0 && (
+                                {focus.length > 0 ? (
                                         <div className="space-y-2">
                                                 {focus.map((area) => (
                                                         <div key={area}>
@@ -175,7 +194,7 @@ export default function Home() {
                                                                         <span>{area}</span>
                                                                         <span>{progress[area] ?? 0}%</span>
                                                                 </div>
-                                                                <div className="h-2 bg-neutral-200 rounded">
+                                                                <div className="h-2 bg-neutral-200 dark:bg-neutral-700 rounded">
                                                                         <div
                                                                                 className="h-2 bg-blue-500 rounded"
                                                                                 style={{ width: `${progress[area] ?? 0}%` }}
@@ -184,6 +203,12 @@ export default function Home() {
                                                         </div>
                                                 ))}
                                         </div>
+                                ) : (
+                                        <p className="text-neutral-500 dark:text-neutral-400 text-sm">
+                                                No focus areas selected. Visit&nbsp;
+                                                <A href="/onboarding">onboarding</A>
+                                                &nbsp;to choose some.
+                                        </p>
                                 )}
                         </div>
 
@@ -191,15 +216,16 @@ export default function Home() {
 				className="rounded-full bg-neutral-200/80 dark:bg-neutral-800/80 flex items-center w-full max-w-3xl border border-transparent hover:border-neutral-300 focus-within:border-neutral-400 hover:focus-within:border-neutral-400 dark:hover:border-neutral-700 dark:focus-within:border-neutral-600 dark:hover:focus-within:border-neutral-600"
 				onSubmit={handleFormSubmit}
 			>
-				<input
-					type="text"
-					className="bg-transparent focus:outline-hidden p-4 w-full placeholder:text-neutral-600 dark:placeholder:text-neutral-400"
-					required
-					placeholder="Ask me anything"
-					value={input}
-					onChange={(e) => setInput(e.target.value)}
-					ref={inputRef}
-				/>
+                                <input
+                                        type="text"
+                                        className="bg-transparent focus:outline-hidden p-4 w-full placeholder:text-neutral-600 dark:placeholder:text-neutral-400"
+                                        required
+                                        placeholder="Ask me anything"
+                                        value={input}
+                                        onChange={(e) => setInput(e.target.value)}
+                                        ref={inputRef}
+                                        disabled={isPending}
+                                />
 
 				<button
 					type="submit"
@@ -211,16 +237,22 @@ export default function Home() {
 				</button>
 			</form>
 
-			<div className="text-neutral-400 dark:text-neutral-600 pt-4 text-center max-w-xl text-balance min-h-28 space-y-4">
-				{messages.length > 0 && (
-					<p>
-						{messages.at(-1)?.content}
-						<span className="text-xs font-mono text-neutral-300 dark:text-neutral-700">
-							{" "}
-							({messages.at(-1)?.latency}ms)
-						</span>
-					</p>
-				)}
+                        <div className="text-neutral-400 dark:text-neutral-600 pt-4 text-center max-w-xl text-balance min-h-28 space-y-4">
+                                {isPending && (
+                                        <div className="flex justify-center">
+                                                <LoadingIcon />
+                                        </div>
+                                )}
+
+                                {messages.length > 0 && (
+                                        <p>
+                                                {messages.at(-1)?.content}
+                                                <span className="text-xs font-mono text-neutral-300 dark:text-neutral-700">
+                                                        {" "}
+                                                        ({messages.at(-1)?.latency}ms)
+                                                </span>
+                                        </p>
+                                )}
 
 				{messages.length === 0 && (
 					<>
@@ -251,14 +283,15 @@ export default function Home() {
 						)}
 					</>
 				)}
-			</div>
+                        </div>
+                        </div>
 
-			<div
-				className={clsx(
-					"absolute size-36 blur-3xl rounded-full bg-linear-to-b from-red-200 to-red-400 dark:from-red-600 dark:to-red-800 -z-50 transition ease-in-out",
-					{
-						"opacity-0": vad.loading || vad.errored,
-						"opacity-30": !vad.loading && !vad.errored && !vad.userSpeaking,
+                        <div
+                                className={clsx(
+                                        "absolute size-36 blur-3xl rounded-full bg-linear-to-b from-red-200 to-red-400 dark:from-red-600 dark:to-red-800 -z-50 transition ease-in-out",
+                                        {
+                                                "opacity-0": vad.loading || vad.errored,
+                                                "opacity-30": !vad.loading && !vad.errored && !vad.userSpeaking,
 						"opacity-100 scale-110": vad.userSpeaking,
 					}
 				)}


### PR DESCRIPTION
## Summary
- center home page layout with progress bars in dark mode
- disable input while requests process and show loading spinner
- surface speech detection and audio playback errors to users

## Testing
- `pnpm lint`
- `pnpm build`
- `pnpm dev`

------
https://chatgpt.com/codex/tasks/task_b_6871bc27be948325bf6ff0b5501a64df